### PR TITLE
[FEAT] Trajectory ID in GML output

### DIFF
--- a/app/experiment.go
+++ b/app/experiment.go
@@ -28,7 +28,6 @@ import (
 	"strings"
 
 	"fmt"
-	//"log"
 	"os"
 	"runtime"
 )

--- a/app/experiment.go
+++ b/app/experiment.go
@@ -62,7 +62,7 @@ type ExperimentParams struct {
 	NrOfThreads          int
 }
 
-// Run the experiment.
+// Run an experiment with the given parameters.
 func Run(args *ExperimentParams) (err error) {
 	defer func() {
 		// converts any panics into errors to avoid crashing the app
@@ -116,7 +116,7 @@ func Run(args *ExperimentParams) (err error) {
 	trajectory.PrintTrajectoriesToFile(exp, outputDir)
 	fmt.Println("Collected trajectories: ")
 	for i := 0; i < utils.MinInt(len(exp.Trajectories), 100); i++ {
-		trajectory.PrintTrajectory(exp.Trajectories[i], exp)
+		trajectory.LogTrajectory(exp.Trajectories[i], exp)
 	}
 
 	// 5. Perform clustering

--- a/app/parseData.go
+++ b/app/parseData.go
@@ -185,7 +185,7 @@ func printIcd10NameMap(table map[string]icd10Name) {
 
 // initializeIcd10NameMap initializes a name map for ICD10 DID -> medical name, level, and categories it belongs to.
 func initializeIcd10NameMap(file string) map[string]icd10Name {
-	icd10NameMap := map[string]icd10Name{} //maps ICD10 DID to a medical name, level, and categories to which it belongs.
+	icd10NameMap := map[string]icd10Name{} // maps ICD10 DID to a medical name, level, and categories to which it belongs.
 	icd10Hierarchy := parseIcd10HierarchyFromXml(file)
 	for _, chap := range icd10Hierarchy.Chapters {
 		category0 := chap.Desc
@@ -284,9 +284,9 @@ func getNonICD10CodesToAddToAnalysis() map[string]string {
 
 // initializeIcd10AnalysisIDMap creates a map ICD10 DID -> analysis DID and a map analysis ID -> medical name. This is
 // useful to remap diagnosis codes used in the input to a higher level in the ICD10 hierarchy. E.g "typhoid fever" and
-// "cholera" are both "infectuous intestinal diseases", so they could both be identified as such during the analysis.
+// "cholera" are both "infectious intestinal diseases", so they could both be identified as such during the analysis.
 // This can be interesting to obtain more global patient trajectories/clusters.
-func intializeIcd10AnalysisMaps(icd10NameMap map[string]icd10Name, level int) (map[string]int, map[int]string, int) {
+func initializeIcd10AnalysisMaps(icd10NameMap map[string]icd10Name, level int) (map[string]int, map[int]string, int) {
 	analysisIdMap := map[string]int{}                     // maps icd 10 code to analysis ID
 	analysisNameMap := map[int]string{}                   // maps analysis ID to a medical name
 	nameToAnalysisIdMap := map[string]int{}               // maps medical name to analysis ID
@@ -298,7 +298,7 @@ func intializeIcd10AnalysisMaps(icd10NameMap map[string]icd10Name, level int) (m
 			continue
 		}
 		var name string
-		if level == icd10Name.level || level > icd10Name.level {
+		if level >= icd10Name.level {
 			name = icd10Name.name
 		} else {
 			name = icd10Name.categories[level]
@@ -598,7 +598,7 @@ func (analysisMap icd10AnalysisMapsFromCCSR) fillInNonICDPatientDiagnoses(patien
 // medical name for an ICD10 Hierarchy passed as xml file and a requested hierarchy level.
 func initializeIcd10AnalysisMapsFromXML(file string, level int) icd10AnalysisMapsFromXML {
 	icd10NameMapFromXml := initializeIcd10NameMap(file) // map ICD10 DID -> ICD 10 Name (medical desc, categories, level)
-	analysisIdMap, analysisNameMap, ctr := intializeIcd10AnalysisMaps(icd10NameMapFromXml, level)
+	analysisIdMap, analysisNameMap, ctr := initializeIcd10AnalysisMaps(icd10NameMapFromXml, level)
 	return icd10AnalysisMapsFromXML{DIDMap: analysisIdMap, NameMap: analysisNameMap, NofDiagnosisCodes: ctr}
 }
 

--- a/app/test_exports.go
+++ b/app/test_exports.go
@@ -20,7 +20,7 @@ package app
 
 var ParseIcd9ToIcd10Mapping = parseIcd9ToIcd10Mapping
 var ParseTriNetXPatientData = parseTriNetXPatientData
-var IntializeIcd10AnalysisMaps = intializeIcd10AnalysisMaps
+var InitializeIcd10AnalysisMaps = initializeIcd10AnalysisMaps
 var InitializeIcd10NameMap = initializeIcd10NameMap
 var InitializeIcd10AnalysisMapsFromXML = initializeIcd10AnalysisMapsFromXML
 var ParseTrinetXPatientDiagnoses = parseTrinetXPatientDiagnoses

--- a/ptra_test/ptra_test.go
+++ b/ptra_test/ptra_test.go
@@ -40,13 +40,13 @@ func TestInitializeIcd10NameMap(t *testing.T) {
 func TestInitializeICD10AnalysisMap(t *testing.T) {
 	file := "./icd10cm_tabular_2022.xml"
 	icd10Names := app.InitializeIcd10NameMap(file)
-	app.IntializeIcd10AnalysisMaps(icd10Names, 0)
-	app.IntializeIcd10AnalysisMaps(icd10Names, 1)
-	app.IntializeIcd10AnalysisMaps(icd10Names, 2)
-	app.IntializeIcd10AnalysisMaps(icd10Names, 3)
-	app.IntializeIcd10AnalysisMaps(icd10Names, 4)
-	app.IntializeIcd10AnalysisMaps(icd10Names, 5)
-	app.IntializeIcd10AnalysisMaps(icd10Names, 6)
+	app.InitializeIcd10AnalysisMaps(icd10Names, 0)
+	app.InitializeIcd10AnalysisMaps(icd10Names, 1)
+	app.InitializeIcd10AnalysisMaps(icd10Names, 2)
+	app.InitializeIcd10AnalysisMaps(icd10Names, 3)
+	app.InitializeIcd10AnalysisMaps(icd10Names, 4)
+	app.InitializeIcd10AnalysisMaps(icd10Names, 5)
+	app.InitializeIcd10AnalysisMaps(icd10Names, 6)
 }
 
 func TestParseTrinetXPatients(t *testing.T) {
@@ -265,7 +265,7 @@ func TestInitCohortsWithFakePatients(t *testing.T) {
 	trajectories := trajectory.BuildTrajectories(exp, 5, 3, 2, 1, 5, 1.0, []trajectory.TrajectoryFilter{})
 	fmt.Println("Collected ", len(trajectories), " trajectories.")
 	for _, traj := range trajectories {
-		trajectory.PrintTrajectory(traj, exp)
+		trajectory.LogTrajectory(traj, exp)
 	}
 	//Output should be:
 	//Building patient trajectories...

--- a/trajectory/trajectory.go
+++ b/trajectory/trajectory.go
@@ -121,7 +121,7 @@ func AddDiagnosis(p *Patient, d *Diagnosis) {
 	p.Diagnoses = append(p.Diagnoses, d)
 }
 
-// sortDiagnosis modifies a given patient's list of diagnoses to be ordered by date.
+// SortDiagnoses modifies a given patient's list of diagnoses to be ordered by date.
 func SortDiagnoses(p *Patient) {
 	diagnoses := p.Diagnoses
 	sort.Slice(diagnoses, func(i, j int) bool {
@@ -158,9 +158,9 @@ func CompactDiagnoses(p *Patient) {
 
 // PatientMap contains all patient information parsed from the input.
 type PatientMap struct {
-	PIDStringMap map[string]int   //maps patient string id onto an int PID
-	Ctr          int              //total nr of patients parsed, also used for creating PIDs
-	PIDMap       map[int]*Patient //maps PID onto a patient object that contain YOB, sex, age group, etc
+	PIDStringMap map[string]int   // maps patient string id onto an int PID
+	Ctr          int              // total nr of patients parsed, also used for creating PIDs
+	PIDMap       map[int]*Patient // maps PID onto a patient object that contain YOB, sex, age group, etc
 	// optional info for logging
 	MaleCtr   int
 	FemaleCtr int
@@ -216,16 +216,16 @@ func MakeDxDPatients(size int) [][][]*Patient {
 // Experiment contains the inputs and outputs for calculating diagnosis trajectories for a specific patient population.
 type Experiment struct {
 	NofAgeGroups, NofRegions, Level, NofDiagnosisCodes int
-	DxDRR                                              [][]float64    //per disease pair, relative risk score (RR)
-	DxDPatients                                        [][][]*Patient //per disease pair, all patients diagnosed
-	DPatients                                          [][]*Patient   //per disease, all patients diagnosed
-	Cohorts                                            []*Cohort      //cohorts in the experiment
-	Name                                               string         //name of the experiment, for printing
+	DxDRR                                              [][]float64    // per disease pair, relative risk score (RR)
+	DxDPatients                                        [][][]*Patient // per disease pair, all patients diagnosed
+	DPatients                                          [][]*Patient   // per disease, all patients diagnosed
+	Cohorts                                            []*Cohort      // cohorts in the experiment
+	Name                                               string         // name of the experiment, for printing
 	NameMap                                            map[int]string // maps diagnosis ID to medical name
 	Trajectories                                       []*Trajectory  // a list of computed trajectories
 	Pairs                                              []*Pair        // a list of all selected pairs that are used to compute trajectories
 	IdMap                                              map[int]string // maps the analysis DID to the original diagnostic ID used in the input data
-	MCtr, FCtr                                         int            //counters for counting nr of males,females,patients
+	MCtr, FCtr                                         int            // counters for counting nr of males,females,patients
 }
 
 // selectCohort returns from a list of cohorts a cohort that matches a specific age group, sex, and region.
@@ -734,9 +734,9 @@ type Trajectory struct {
 	Diagnoses      []int            // A list of diagnosis codes that represent the trajectory
 	PatientNumbers []int            // A list with nr of patients for each transition in the trajectory
 	Patients       [][]*Patient     // A list of patients with the given trajectory
-	TrajMap        map[*Patient]int //Maps patient IDs onto a diagnosis index for trajectory tracking
+	TrajMap        map[*Patient]int // Maps patient IDs onto a diagnosis index for trajectory tracking
 	ID             int              // An analysis id
-	Cluster        int              //A cluster ID to which this trajectory is assigned to
+	Cluster        int              // A cluster ID to which this trajectory is assigned to
 }
 
 // extendTrajectory tries to extend a given trajectory (currentT) with a diagnosis (d). It returns a map which maps all
@@ -754,7 +754,7 @@ func extendTrajectory(currentT *Trajectory, d int, minTime, maxTime float64) map
 
 // BuildTrajectories calculates the trajectories for an experiment. The trajectories are constrained by: a
 // minimum number of patients in the trajectory (minPatients), a maximum number of diagnoses in the trajectory (maxLength),
-// a minumum number of diagnoses in the trajectory (minLength), a minimum RR for each diagnosis transition (minRR), and
+// a minimum number of diagnoses in the trajectory (minLength), a minimum RR for each diagnosis transition (minRR), and
 // a list of filters.
 func BuildTrajectories(exp *Experiment, minPatients, maxLength, minLength int, minTime, maxTime, minRR float64,
 	filters []TrajectoryFilter) []*Trajectory {


### PR DESCRIPTION
## Features

+ Adds TID (trajectory ID) to the `.gml` output files so we can visualize the whole trajectory in the FE.

### Visual

![image](https://github.com/user-attachments/assets/9ebb2ad6-84ea-4ac1-949f-07e69c332752)
![image](https://github.com/user-attachments/assets/9decb963-01fd-478b-a1e9-651351cd085c)
 